### PR TITLE
Run a custom prepare script included in the app

### DIFF
--- a/src/sandbox.sh
+++ b/src/sandbox.sh
@@ -191,10 +191,7 @@ function create_sandbox () {
 	sandbox_description=$( echo_sandbox_description "${sandbox_tag}" ) || die
 
 	log "Creating ${sandbox_description}"
-
-	if ! [ -d "${HALCYON_DIR}/sandbox" ]; then
-		cabal_create_sandbox "${HALCYON_DIR}/sandbox" || die
-	fi
+	cabal_create_sandbox "${HALCYON_DIR}/sandbox" || die
 }
 
 
@@ -538,8 +535,6 @@ function install_extended_sandbox () {
 
 	rm -f "${HALCYON_DIR}/sandbox/tag" "${HALCYON_DIR}/sandbox/cabal.config" || die
 
-	create_sandbox "${build_dir}" || die
-	customize_sandbox "${build_dir}" || die
 	build_sandbox "${build_dir}" "${sandbox_constraints}" "${unhappy_workaround}" "${sandbox_tag}" || die
 	strip_sandbox || die
 	cache_sandbox || die


### PR DESCRIPTION
I quickly hacked this together in order to help me get past #3 quickly. I suspect you probably have something more elegant in mind @mietek, but I thought I'd share it anyway.

It sources a custom prepare script included with the app under `deploy/prepare.sh`. I'm using this to add additional sources to the sandbox. E.g. to get around the issue with `persistent-mysql` depending on `libpcre`:

```
function custom_prepare () {
  expect_vars HALCYON_DIR

  local sandbox_dir
  expect_args sandbox_dir -- "$@"

  local cwd
  cwd=`pwd`

  log 'Install custom mysql-simple (avoid installing libpcre)'
  git clone https://github.com/rehno-lindeque/mysql-simple.git -b remove-pcre
  cd ${sandbox_dir}
  cabal sandbox add-source "${cwd}/mysql-simple"
  log_end 'done'
}
```
