### PR TITLE
Extend unhappy workaround for bytestring-lexing

### DIFF
--- a/src/sandbox.sh
+++ b/src/sandbox.sh
@@ -529,7 +529,7 @@ function install_sandbox () {
 
 	local unhappy_workaround
 	unhappy_workaround=0
-	if filter_matching '^(language-javascript|haskell-src-exts|pandoc) ' <<<"${sandbox_constraints}" |
+	if filter_matching '^(language-javascript|haskell-src-exts|pandoc|bytestring-lexing) ' <<<"${sandbox_constraints}" |
 		match_at_least_one >'/dev/null'
 	then
 		unhappy_workaround=1


### PR DESCRIPTION
Extends the workaround for `bytestring-lexing` which has a build-tool dependency on `alex`.

(In our cut-down version of Yesod we don't depend on any of `language-javascript` `haskell-src-exts` `pandoc`, but we do depend on `hedis` which in turn uses `bytestring-lexing`.)
